### PR TITLE
Use function overloads to infer return type from parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ yarn add identify-package-manager
 
 ### Usage
 
-```Typescript
-import { identifyPackageManager, PackageManagerName, PackageManagerInfo } from "identify-package-manager";
+```typescript
+import { identifyPackageManager } from "identify-package-manager";
 
 // get name of package manager:
-const packageManager: PackageManagerName = identifyPackageManager(true);
+const packageManager = identifyPackageManager(true);
 console.log(packageManager);
 // ^ might output 'yarn-berry' for instance
 
 // get entire info about package manager:
-const packageManagerInfo: PackageManagerInfo = identifyPackageManager();
+const packageManagerInfo = identifyPackageManager();
 console.log(packageManagerInfo);
 // ^ might output the following for instance:
 // {

--- a/src/identifyPackageManager.ts
+++ b/src/identifyPackageManager.ts
@@ -4,9 +4,9 @@ import { identifyMonorepoRoot } from "identify-monorepo-root";
 import { PackageManagerInfo, PackageManagerName } from "./PackageManagerInfo";
 import { getDetailedVersionFromSimple } from "./getDetailedVersionFromSimple";
 
-export const identifyPackageManager = (
-  returnNameOnly: boolean
-): PackageManagerName | PackageManagerInfo => {
+export function identifyPackageManager(returnNameOnly?: false): PackageManagerInfo;
+export function identifyPackageManager(returnNameOnly: true): PackageManagerName;
+export function identifyPackageManager(returnNameOnly?: boolean) {
   const who = whoAmINow();
 
   if (!who.isServerApp) {


### PR DESCRIPTION
Changes the `identifyPackageManager` declaration to use function overloads to infer the return type from the `returnNameOnly` parameter. Removes the need to explicitly define the return type.

```ts
const name = identifyPackageManager(true);
//     ^? PackageManagerName
const info = identifyPackageManager();
//     ^? PackageManagerInfo
```